### PR TITLE
Fix divide by zero

### DIFF
--- a/huffman/huffman.go
+++ b/huffman/huffman.go
@@ -107,6 +107,10 @@ func (encoder *HuffmanEncoder_V1) GenerateHuffman(data []byte, allowed_charset *
 			return codes, nil
 		}
 
+		if valid_length == 0 {
+			return []byte{0}, errors.New("No result.")
+		}
+
 		prev_code := int(codes[codes_length-1])
 		prev_symbol := symbols[codes_length-1]
 		symbol := symbols[codes_length]


### PR DESCRIPTION
Hi @mikispag,

this is super very nice research!!! :+1: 

I forked your repo and generated simple extension to bypass Flash protection for sites that parse the callback as UTF8 (if you are interested see here: https://github.com/topolik/rosettaflash/compare/utf8checksum)

I found in some cases valid_length is zero and the execution fails on this line with "divide by zero": https://github.com/topolik/rosettaflash/blob/135e5d6cf5ca4242b8478ae42e8a32168e9530ab/huffman/huffman.go#L120

I'm sorry I don't know go language, but it works so feel free to merge it if you wish :)

Thanks!

Best,
-- tom
